### PR TITLE
Add Rubies until 2.1, 2.2,, 2.5 to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,15 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - ruby-head
   - jruby-19mode
-  - rbx-2
+  - rbx-3
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in mono_logger.gemspec
 gemspec
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.0")
+  gem 'logger-application'
+end
 gem 'coveralls', require: false

--- a/test/mri_logger_test.rb
+++ b/test/mri_logger_test.rb
@@ -11,6 +11,8 @@ Coveralls.wear!
 
 require 'minitest/autorun'
 require 'mono_logger'
+# Logger::Application was dropped at Ruby 2.2.
+require 'logger-application' unless defined?(Logger::Application)
 require 'tempfile'
 
 if defined? Minitest::Test


### PR DESCRIPTION
I added Rubies to Travis CI.
I also fixed the unit tests on Ruby >= 2.2.0.

`rbx-2` is not available on Travis any more. `rbx-3` is available.
`ruby-head` as a `allow_failures` is a technique commonly used to catch up latest Ruby. You can see it on Rails and other popular RubyGem packages.

Let me run the CI.

