### PR TITLE
Fix compatibility with Ruby HEAD & add Ruby versions to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - head
+          - '3.2'
+          - '3.1'
           - '3.0'
           - 2.7
           - 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ gemspec
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.0")
   gem 'logger-application'
 end
-gem 'coveralls', require: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MonoLogger
 
-[![Build Status](https://travis-ci.org/steveklabnik/mono_logger.png?branch=master)](https://travis-ci.org/steveklabnik/mono_logger) [![Code Climate](https://codeclimate.com/github/steveklabnik/mono_logger.png)](https://codeclimate.com/github/steveklabnik/mono_logger) [![Coverage Status](https://coveralls.io/repos/steveklabnik/mono_logger/badge.png)](https://coveralls.io/r/steveklabnik/mono_logger)
+[![Build Status](https://travis-ci.org/steveklabnik/mono_logger.png?branch=master)](https://travis-ci.org/steveklabnik/mono_logger) [![Code Climate](https://codeclimate.com/github/steveklabnik/mono_logger.png)](https://codeclimate.com/github/steveklabnik/mono_logger)
 
 Ruby's stdlib Logger wraps all IO in mutexes. Ruby 2.0 doesn't allow you to
 request a lock in a trap handler because that could deadlock. This gem fixes

--- a/lib/mono_logger.rb
+++ b/lib/mono_logger.rb
@@ -28,11 +28,8 @@ class MonoLogger < Logger
   # Create an instance.
   #
   def initialize(logdev, shift_age=nil, shift_size=nil)
-    @progname = nil
-    @level = DEBUG
-    @default_formatter = Formatter.new
-    @formatter = nil
-    @logdev = nil
+    super(nil)
+
     if logdev
       @logdev = LocklessLogDevice.new(logdev)
     end

--- a/test/mri_logger_test.rb
+++ b/test/mri_logger_test.rb
@@ -103,16 +103,19 @@ class TestLogger < Minitest::Test
   end
 
   def test_datetime_format
+    # We use strip because we don't care about the upstream changes that
+    # happened to whitespace, and this makes the test behave the same
+    # regardless of Ruby/Logger version.
     dummy = STDERR
     logger = Logger.new(dummy)
     log = log_add(logger, INFO, "foo")
-    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+ $/, log.datetime)
+    assert_match(/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\s*\d+$/, log.datetime.strip)
     logger.datetime_format = "%d%b%Y@%H:%M:%S"
     log = log_add(logger, INFO, "foo")
-    assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime)
+    assert_match(/^\d\d\w\w\w\d\d\d\d@\d\d:\d\d:\d\d$/, log.datetime.strip)
     logger.datetime_format = ""
     log = log_add(logger, INFO, "foo")
-    assert_match(/^$/, log.datetime)
+    assert_match(/^$/, log.datetime.strip)
   end
 
   def test_formatter

--- a/test/mri_logger_test.rb
+++ b/test/mri_logger_test.rb
@@ -1,13 +1,4 @@
 # coding: US-ASCII
-require 'simplecov'
-SimpleCov.start do
-  add_filter do |source_file|
-    source_file.filename =~ /test/
-  end
-end
-
-require 'coveralls'
-Coveralls.wear!
 
 require 'minitest/autorun'
 require 'mono_logger'


### PR DESCRIPTION
Compatibility with Ruby HEAD is broken due to changes in ruby/logger#85.

```ruby
class Logger
  def level
    @level_override[Fiber.current] || https://github.com/Level?type=source
    #              ^^^^^^^^^^^^^^^ undefined method `[]' for nil:NilClass (NoMethodError)
  end
end
```

See https://github.com/resque/resque/issues/1856 for example.

ruby/logger#85 introduced setting `@level_override` in `initialize`. Since we don't call `super`, we need to set it ourselves.

This also adds Ruby `3.1`, `3.2`, & `HEAD` to the CI matrix.